### PR TITLE
Set revm-interpreter ver to avoid conflict dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ revm = { version = "6.1.0", features = [
     "optional_eip3607",
     "optional_gas_refund",
 ] }
+revm-interpreter = { version = "=3.1" }
 
 tokio = { version = "1.35.1", features = ["full"] }
 thiserror = "1.0.37"


### PR DESCRIPTION
After trying to integrate this into a bigger project (or when I delete Cargo.lock) I've run into dependencies on conflicting versions of revm-primitives.
Explicitly setting the revm-interpreter version avoids the issue.